### PR TITLE
Fixed Repeated audio play after admin reconnection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5364,7 +5364,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5729,7 +5730,8 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5777,6 +5779,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5815,11 +5818,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },

--- a/src/components/Stream/Stream.tsx
+++ b/src/components/Stream/Stream.tsx
@@ -268,13 +268,11 @@ class Stream extends Component<IStreamProps, IStreamState> {
         this.props.onChangeCurrentTabId(1);
 
         window.onbeforeunload = (event) => {
-            return this.props.connectingStatus
-                    ? false
-                    : null;
+            return this.disconnectFromServer();
         };
     }
 
-    public async componentWillUnmount() {
+    public async disconnectFromServer(){
         if (this.props.connectingStatus) {
             if (this.props.isPlaying) {
                 await this.pause();
@@ -287,7 +285,10 @@ class Stream extends Component<IStreamProps, IStreamState> {
         }
 
         this.props.onChangeStreamStateToInitial();
-        window.onbeforeunload = null;
+    }
+
+    public async componentWillUnmount() {
+        await this.disconnectFromServer();
     }
 
     private handleError = (response: Response) => {


### PR DESCRIPTION
Repeated audio play after admin reconnection
Way to recreate:
1. Connect client to stream
2. Close admin tab
3. Open admin tab
4. Start stream

Result:
Previous stream did not end, after reconnection audios from different stream overlap